### PR TITLE
fix: restore terminal scrollback after resize and show all agents in usage panel

### DIFF
--- a/cloud/src-client/app.js
+++ b/cloud/src-client/app.js
@@ -1508,9 +1508,28 @@ import { initGitGraphDeps, renderGitGraphPane, fetchGitGraphData } from './modul
       const results = await Promise.allSettled(
         onlineAgents.map(a => agentRequest('GET', '/api/usage', null, a.agentId))
       );
-      const first = results.find(r => r.status === 'fulfilled' && r.value);
-      if (first) {
-        agentsUsageData = first.value;
+      let anySuccess = false;
+      const newByAgent = {};
+      for (let i = 0; i < onlineAgents.length; i++) {
+        const a = onlineAgents[i];
+        const r = results[i];
+        const hostname = a.displayName || a.hostname || a.agentId;
+        if (r.status === 'fulfilled' && r.value) {
+          anySuccess = true;
+          newByAgent[a.agentId] = { hostname, data: r.value };
+        } else {
+          // Keep failed agents visible with error indicator
+          const errMsg = r.status === 'rejected'
+            ? (r.reason?.message || 'Failed to fetch usage')
+            : 'No data';
+          newByAgent[a.agentId] = { hostname, data: null, error: errMsg };
+        }
+      }
+      agentsUsageByAgent = newByAgent;
+      if (anySuccess) {
+        // Keep legacy single-agent data as first result for header pct
+        const firstEntry = Object.values(newByAgent).find(e => e.data);
+        agentsUsageData = firstEntry ? firstEntry.data : null;
         agentsUsageLastUpdated = Date.now();
         agentsUsageFetchError = null;
         renderAgentsHud();
@@ -1595,10 +1614,23 @@ import { initGitGraphDeps, renderGitGraphPane, fetchGitGraphData } from './modul
       `;
     }
 
-    addBlock('5-hour window', agentsUsageData.five_hour);
-    addBlock('7-day window', agentsUsageData.seven_day);
-    addBlock('7-day sonnet', agentsUsageData.seven_day_sonnet);
-    if (agentsUsageData.seven_day_opus) addBlock('7-day opus', agentsUsageData.seven_day_opus);
+    for (const entry of agentEntries) {
+      // Always show machine name header with device color
+      const dc = getDeviceColor(entry.hostname);
+      const nameColor = dc ? dc.text : '#4ec9b0';
+      const borderColor = dc ? dc.border : 'rgba(78,201,176,0.2)';
+      blocks += `<div style="font-size:11px;color:${nameColor};margin:${blocks ? '10px' : '0'} 0 4px;font-weight:600;border-bottom:1px solid ${borderColor};padding-bottom:3px;">${entry.hostname}</div>`;
+      const d = entry.data;
+      if (!d) {
+        // Show error state for agents whose usage request failed
+        blocks += `<div style="font-size:11px;color:#e55;padding:4px 0;">Usage unavailable</div>`;
+        continue;
+      }
+      addBlock('5-hour window', d.five_hour);
+      addBlock('7-day window', d.seven_day);
+      addBlock('7-day sonnet', d.seven_day_sonnet);
+      if (d.seven_day_opus) addBlock('7-day opus', d.seven_day_opus);
+    }
 
     // "Last updated" indicator + error state
     if (agentsUsageLastUpdated) {
@@ -7370,11 +7402,30 @@ import { initGitGraphDeps, renderGitGraphPane, fetchGitGraphData } from './modul
     // fit() itself changes the terminal element size.
     let fitting = false;
 
+    // When fit() increases rows, xterm absorbs scrollback lines into the
+    // visible area. tmux then repaints and overwrites those absorbed lines,
+    // permanently losing the scrollback. Track this and schedule a reattach
+    // to re-inject history from the agent.
+    let reattachTimer = null;
+
     function safeFit() {
       if (fitting) return;
       fitting = true;
       try {
+        const baseYBefore = xterm.buffer.active.baseY;
         fitAddon.fit();
+        const baseYAfter = xterm.buffer.active.baseY;
+
+        // Scrollback was absorbed — schedule a reattach to restore history.
+        // Debounced so rapid resizes only trigger one reattach.
+        if (baseYBefore > 0 && baseYAfter < baseYBefore) {
+          if (reattachTimer) clearTimeout(reattachTimer);
+          reattachTimer = setTimeout(() => {
+            reattachTimer = null;
+            const pane = state.panes.find(p => p.id === paneData.id);
+            if (pane) reattachTerminal(pane);
+          }, 600); // wait for tmux repaint to settle
+        }
       } catch (e) {
         // Ignore fit errors
       } finally {


### PR DESCRIPTION
## Summary
- **Terminal scrollback loss on resize**: When `fitAddon.fit()` increases rows, xterm absorbs scrollback lines into the visible area. tmux then repaints and overwrites them, permanently losing scrollback. Fixed by detecting `baseY` decrease after fit and scheduling a debounced `reattachTerminal()` to re-inject history from the agent.
- **Usage panel hiding failed agents**: Agents whose `/api/usage` request failed were silently dropped from the usage panel. Now they remain visible with a "Usage unavailable" indicator so all online machines are always shown.

## Test plan
- [ ] Open a terminal with scrollback history, resize the pane taller → scrollbar should persist (brief reattach flash at ~600ms is expected)
- [ ] With multiple machines, disconnect one machine's Claude credentials → usage panel should show "Usage unavailable" for that machine instead of hiding it

🤖 Generated with [Claude Code](https://claude.com/claude-code)