### PR TITLE
fix: pane layout persistence, mention click, and server error handling

### DIFF
--- a/cloud/src-client/app.js
+++ b/cloud/src-client/app.js
@@ -562,6 +562,7 @@ import { initGitGraphDeps, renderGitGraphPane, fetchGitGraphData } from './modul
       clearTimeout(cloudLayoutTimers.get(paneId));
       cloudLayoutTimers.delete(paneId);
     }
+    cloudLayoutPending.delete(paneId);
     cloudFetch('DELETE', `/api/layouts/${paneId}`)
       .catch(e => console.error('[Cloud] Layout delete failed:', e.message));
   }

--- a/cloud/src-client/app.js
+++ b/cloud/src-client/app.js
@@ -379,41 +379,71 @@ import { initGitGraphDeps, renderGitGraphPane, fetchGitGraphData } from './modul
 
   // Cloud layout persistence (debounced per-pane, 500ms)
   const cloudLayoutTimers = new Map();
+  // Track panes with pending saves so we can flush on page unload
+  const cloudLayoutPending = new Map(); // paneId -> pane ref
+
+  function buildLayoutPayload(pane) {
+    const metadata = {};
+    if (pane.zoomLevel && pane.zoomLevel !== 100) metadata.zoomLevel = pane.zoomLevel;
+    if (pane.textOnly) metadata.textOnly = true;
+    if (pane.type === 'folder' && pane.folderPath) metadata.folderPath = pane.folderPath;
+    if (pane.beadsTag) metadata.beadsTag = pane.beadsTag;
+    if (pane.device) metadata.device = pane.device;
+    if (pane.filePath) metadata.filePath = pane.filePath;
+    if (pane.fileName) metadata.fileName = pane.fileName;
+    if (pane.url) metadata.url = pane.url;
+    if (pane.repoPath) metadata.repoPath = pane.repoPath;
+    if (pane.repoName) metadata.repoName = pane.repoName;
+    if (pane.graphMode && pane.graphMode !== 'svg') metadata.graphMode = pane.graphMode;
+    if (pane.projectPath) metadata.projectPath = pane.projectPath;
+    if (pane.dirPath) metadata.dirPath = pane.dirPath;
+    if (pane.claudeSessionId) metadata.claudeSessionId = pane.claudeSessionId;
+    if (pane.claudeSessionName) metadata.claudeSessionName = pane.claudeSessionName;
+    if (pane.workingDir) metadata.workingDir = pane.workingDir;
+    if (pane.shortcutNumber) metadata.shortcutNumber = pane.shortcutNumber;
+    if (pane.paneName) metadata.paneName = pane.paneName;
+    return {
+      paneType: pane.type,
+      positionX: pane.x,
+      positionY: pane.y,
+      width: pane.width,
+      height: pane.height,
+      zIndex: pane.zIndex || 0,
+      agentId: pane.agentId || activeAgentId,
+      metadata: Object.keys(metadata).length > 0 ? metadata : null
+    };
+  }
+
   function cloudSaveLayout(pane) {
     if (cloudLayoutTimers.has(pane.id)) clearTimeout(cloudLayoutTimers.get(pane.id));
+    cloudLayoutPending.set(pane.id, pane);
     cloudLayoutTimers.set(pane.id, setTimeout(() => {
       cloudLayoutTimers.delete(pane.id);
-      const metadata = {};
-      if (pane.zoomLevel && pane.zoomLevel !== 100) metadata.zoomLevel = pane.zoomLevel;
-      if (pane.textOnly) metadata.textOnly = true;
-      if (pane.type === 'folder' && pane.folderPath) metadata.folderPath = pane.folderPath;
-      if (pane.beadsTag) metadata.beadsTag = pane.beadsTag;
-      if (pane.device) metadata.device = pane.device;
-      if (pane.filePath) metadata.filePath = pane.filePath;
-      if (pane.fileName) metadata.fileName = pane.fileName;
-      if (pane.url) metadata.url = pane.url;
-      if (pane.repoPath) metadata.repoPath = pane.repoPath;
-      if (pane.repoName) metadata.repoName = pane.repoName;
-      if (pane.graphMode && pane.graphMode !== 'svg') metadata.graphMode = pane.graphMode;
-      if (pane.projectPath) metadata.projectPath = pane.projectPath;
-      if (pane.dirPath) metadata.dirPath = pane.dirPath;
-      if (pane.claudeSessionId) metadata.claudeSessionId = pane.claudeSessionId;
-      if (pane.claudeSessionName) metadata.claudeSessionName = pane.claudeSessionName;
-      if (pane.workingDir) metadata.workingDir = pane.workingDir;
-      if (pane.shortcutNumber) metadata.shortcutNumber = pane.shortcutNumber;
-      if (pane.paneName) metadata.paneName = pane.paneName;
-      cloudFetch('PUT', `/api/layouts/${pane.id}`, {
-        paneType: pane.type,
-        positionX: pane.x,
-        positionY: pane.y,
-        width: pane.width,
-        height: pane.height,
-        zIndex: pane.zIndex || 0,
-        agentId: pane.agentId || activeAgentId,
-        metadata: Object.keys(metadata).length > 0 ? metadata : null
-      }).catch(e => console.error('[Cloud] Layout save failed:', e.message));
+      cloudLayoutPending.delete(pane.id);
+      cloudFetch('PUT', `/api/layouts/${pane.id}`, buildLayoutPayload(pane))
+        .catch(e => console.error('[Cloud] Layout save failed:', e.message));
     }, 500));
   }
+
+  // Flush any pending layout saves on page unload using keepalive fetch
+  // so positions are never lost when the user refreshes mid-debounce
+  window.addEventListener('beforeunload', () => {
+    for (const [paneId, pane] of cloudLayoutPending) {
+      if (cloudLayoutTimers.has(paneId)) {
+        clearTimeout(cloudLayoutTimers.get(paneId));
+        cloudLayoutTimers.delete(paneId);
+      }
+      const payload = buildLayoutPayload(pane);
+      fetch(`/api/layouts/${paneId}`, {
+        method: 'PUT',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+        keepalive: true
+      }).catch(() => {});
+    }
+    cloudLayoutPending.clear();
+  });
 
   // Save a recent pane context to cloud (fire-and-forget)
   function saveRecentContext(paneType, context, label, agentId) {
@@ -538,9 +568,12 @@ import { initGitGraphDeps, renderGitGraphPane, fetchGitGraphData } from './modul
 
   // Cloud view state (debounced 1s)
   let cloudViewStateTimer = null;
+  let cloudViewStateDirty = false;
   function cloudSaveViewState() {
+    cloudViewStateDirty = true;
     if (cloudViewStateTimer) clearTimeout(cloudViewStateTimer);
     cloudViewStateTimer = setTimeout(() => {
+      cloudViewStateDirty = false;
       cloudFetch('PUT', '/api/view-state', {
         zoom: state.zoom,
         panX: state.panX,
@@ -548,6 +581,20 @@ import { initGitGraphDeps, renderGitGraphPane, fetchGitGraphData } from './modul
       }).catch(e => console.error('[Cloud] View state save failed:', e.message));
     }, 1000);
   }
+
+  // Also flush view state on page unload
+  window.addEventListener('beforeunload', () => {
+    if (cloudViewStateDirty) {
+      if (cloudViewStateTimer) clearTimeout(cloudViewStateTimer);
+      fetch('/api/view-state', {
+        method: 'PUT',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ zoom: state.zoom, panX: state.panX, panY: state.panY }),
+        keepalive: true
+      }).catch(() => {});
+    }
+  });
 
   // Cloud note sync (debounced per-note, 500ms)
   const cloudNoteTimers = new Map();
@@ -8889,11 +8936,13 @@ import { initGitGraphDeps, renderGitGraphPane, fetchGitGraphData } from './modul
           <div class="mention-path">${escapeHtml(info.path)}</div>
           ${beadsInfo}
         </div>`;
-        overlay.addEventListener('click', (e) => {
+        overlay.addEventListener('mousedown', (e) => {
           e.stopPropagation();
+          e.preventDefault();
+          const encoded = btoa(unescape(encodeURIComponent(mentionPayload.text)));
           sendWs('terminal:input', {
             terminalId: paneData.id,
-            data: btoa(mentionPayload.text)
+            data: encoded
           }, paneData.agentId);
           // Auto-set beads tag when mentioning a beads issue to a terminal
           if (mentionPayload.type === 'beads' && mentionPayload.issueId) {

--- a/cloud/src/db/agents.js
+++ b/cloud/src/db/agents.js
@@ -73,6 +73,21 @@ export function updateAgentDisplayName(agentId, displayName) {
 }
 
 /**
+ * Ensure an agent exists in the DB (creates if missing).
+ * Needed for dev mode where agents bypass the registration flow.
+ */
+export function ensureAgentExists(agentId, userId, hostname, os) {
+  const db = getDb();
+  const existing = db.prepare('SELECT id FROM agents WHERE id = ?').get(agentId);
+  if (!existing) {
+    db.prepare(`
+      INSERT INTO agents (id, user_id, hostname, os, token_hash)
+      VALUES (?, ?, ?, ?, 'dev')
+    `).run(agentId, userId, hostname, os || null);
+  }
+}
+
+/**
  * Delete an agent by ID.
  */
 export function deleteAgent(agentId) {

--- a/cloud/src/routes/layouts.js
+++ b/cloud/src/routes/layouts.js
@@ -44,8 +44,13 @@ export function setupLayoutRoutes(app) {
 
   // PUT /api/layouts/:paneId — upsert a single pane layout
   app.put('/api/layouts/:paneId', requireAuth, (req, res) => {
-    upsertPaneLayout(req.user.id, { id: req.params.paneId, ...req.body });
-    res.json({ ok: true });
+    try {
+      upsertPaneLayout(req.user.id, { id: req.params.paneId, ...req.body });
+      res.json({ ok: true });
+    } catch (e) {
+      console.error(`[layouts] PUT /api/layouts/${req.params.paneId} failed:`, e.message);
+      res.status(500).json({ error: e.message });
+    }
   });
 
   // DELETE /api/layouts/:paneId — remove a pane from cloud layout

--- a/cloud/src/ws/agentHandler.js
+++ b/cloud/src/ws/agentHandler.js
@@ -16,7 +16,7 @@
 
 import { WebSocket } from 'ws';
 import { verifyAgentToken } from '../auth/agentAuth.js';
-import { updateLastSeen, getAgentById } from '../db/agents.js';
+import { updateLastSeen, getAgentById, ensureAgentExists } from '../db/agents.js';
 import { checkAgentLimit } from '../billing/enforcement.js';
 import { recordEvent } from '../db/events.js';
 import { isVersionOutdated } from '../utils/version.js';
@@ -88,7 +88,8 @@ export function handleAgentConnection(ws, userAgents, userBrowsers, latestAgentV
             }
             // Normalize OS name: Node's process.platform reports 'darwin' but UI expects 'macos'
             const agentOs = msg.payload.os === 'darwin' ? 'macos' : (msg.payload.os || 'unknown');
-            // Look up created_at from DB for chronological ordering
+            // Ensure agent exists in DB (dev mode skips registration)
+            ensureAgentExists(agentId, userId, msg.payload.hostname || 'unknown', agentOs);
             const agentRecord = getAgentById(agentId);
             const createdAt = agentRecord?.created_at || new Date().toISOString();
             userAgents.get(userId).set(agentId, {


### PR DESCRIPTION
## Summary
- **Layout saves always returning 500**: Dev-mode agent (`agent_dev_local`) was never registered in the `agents` table, causing FK constraint violation on every `pane_layouts` INSERT. Added `ensureAgentExists()` to auto-register agents on WebSocket connect.
- **Layout lost on refresh**: `cloudSaveLayout` uses a 500ms debounce — refreshing mid-debounce lost the save. Added `beforeunload` handler with `fetch({ keepalive: true })` to flush pending saves. Same fix applied to view state (zoom/pan).
- **Mention overlay not clickable**: The pane's capture-phase `mousedown` handler called `focusTerminalInput()` before the overlay's `click` event could fire. Changed overlay from `click` to `mousedown` with `preventDefault()`. Also fixed `btoa()` encoding to handle non-ASCII file paths.
- **Server error handling**: Added try-catch to `PUT /api/layouts/:paneId` so DB errors return proper 500 responses instead of crashing silently.

## Test plan
- [ ] Move a pane, immediately refresh → position should be preserved
- [ ] Open file from folder pane, click @ mention, click red "mention here" on Claude terminal → file path should be typed into terminal
- [ ] Check server logs for layout save errors (should be none)

🤖 Generated with [Claude Code](https://claude.com/claude-code)