### PR TITLE
feat: pane connection lines and follow mode for folder/git-graph

### DIFF
--- a/cloud/public/styles.css
+++ b/cloud/public/styles.css
@@ -3936,6 +3936,25 @@ body.minimap-hidden #controls {
   padding: 8px 10px;
   display: block;
 }
+.git-graph-no-repo {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  gap: 8px;
+  opacity: 0.5;
+}
+.git-graph-no-repo-label {
+  font-size: 13px;
+  font-weight: 500;
+  color: rgba(255,255,255,0.4);
+}
+.git-graph-no-repo-path {
+  font-size: 11px;
+  font-family: 'JetBrains Mono', monospace;
+  color: rgba(255,255,255,0.25);
+}
 
 /* SVG graph scroll container */
 .gg-scroll-container {

--- a/cloud/src-client/app.js
+++ b/cloud/src-client/app.js
@@ -2036,7 +2036,9 @@ import { initGitGraphDeps, renderGitGraphPane, fetchGitGraphData } from './modul
 
       // Update paneData.workingDir from live tmux cwd
       if (paneData && info && info.cwd) {
+        const cwdChanged = paneData.workingDir !== info.cwd;
         paneData.workingDir = info.cwd;
+        if (cwdChanged) renderConnectionLines();
       }
       // Update Claude session ID/name and persist to cloud when they change
       if (paneData && info && info.claudeSessionId) {
@@ -3778,6 +3780,9 @@ import { initGitGraphDeps, renderGitGraphPane, fetchGitGraphData } from './modul
     if (lastReceivedClaudeStates) {
       updateClaudeStates(lastReceivedClaudeStates);
     }
+
+    // Draw connection lines after all panes are loaded
+    renderConnectionLines();
   }
 
   /**
@@ -4929,6 +4934,8 @@ import { initGitGraphDeps, renderGitGraphPane, fetchGitGraphData } from './modul
       // Remove from cloud layout
       cloudDeleteLayout(paneId);
 
+      renderConnectionLines();
+
     } catch (e) {
       console.error('[App] Error deleting pane:', e);
     }
@@ -5993,6 +6000,9 @@ import { initGitGraphDeps, renderGitGraphPane, fetchGitGraphData } from './modul
         ${paneNameHtml(paneData)}
         <div class="pane-header-right">
           ${shortcutBadgeHtml(paneData)}
+          <button class="folder-toolbar-btn follow-pin-btn" data-tooltip="${paneData._pinned ? 'Unpin (follow terminal)' : 'Pin path (stop following)'}" style="color:${paneData._pinned ? '#e8a060' : 'rgba(255,255,255,0.4)'};">
+            <svg viewBox="0 0 24 24" width="14" height="14" fill="${paneData._pinned ? 'currentColor' : 'none'}" stroke="currentColor" stroke-width="2"><path d="M12 2C9.24 2 7 4.24 7 7c0 1.38.56 2.63 1.46 3.54L12 22l3.54-11.46A5 5 0 0 0 17 7c0-2.76-2.24-5-5-5z"/><circle cx="12" cy="7" r="1.5" fill="${paneData._pinned ? '#1a1a2e' : 'none'}"/></svg>
+          </button>
           <button class="folder-toolbar-btn folder-new-file-btn" data-tooltip="New File">
             <svg viewBox="0 0 24 24" width="14" height="14"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8l-6-6z" fill="none" stroke="currentColor" stroke-width="2"/><line x1="12" y1="11" x2="12" y2="17" stroke="currentColor" stroke-width="2"/><line x1="9" y1="14" x2="15" y2="14" stroke="currentColor" stroke-width="2"/></svg>
           </button>
@@ -6261,6 +6271,17 @@ import { initGitGraphDeps, renderGitGraphPane, fetchGitGraphData } from './modul
       } catch (e) {
         alert('Failed to open file: ' + e.message);
       }
+    }
+
+    // Toolbar: Pin/Unpin (follow mode)
+    const pinBtn = pane.querySelector('.follow-pin-btn');
+    if (pinBtn) {
+      pinBtn.addEventListener('click', (e) => {
+        e.stopPropagation();
+        paneData._pinned = !paneData._pinned;
+        // Re-render to update button state
+        renderFolderPane(paneData);
+      });
     }
 
     // Toolbar: New File
@@ -7863,6 +7884,11 @@ import { initGitGraphDeps, renderGitGraphPane, fetchGitGraphData } from './modul
       }
       focusPane(paneData);
       focusTerminalInput(paneData.id);
+      // Follow mode: only on click (not hover) to avoid path changes while passing through panes
+      if (paneData.type === 'terminal' && paneData.workingDir) {
+        if (followModeDebounce) clearTimeout(followModeDebounce);
+        followModeDebounce = setTimeout(() => triggerFollowMode(paneData), 200);
+      }
     }, true); // capture phase
 
     // Track touch start position for tap-vs-drag detection
@@ -8307,6 +8333,7 @@ import { initGitGraphDeps, renderGitGraphPane, fetchGitGraphData } from './modul
       } else {
         cloudSaveLayout(paneData);
       }
+      renderConnectionLines();
 
       document.removeEventListener('mousemove', moveHandler);
       document.removeEventListener('touchmove', moveHandler);
@@ -8436,6 +8463,7 @@ import { initGitGraphDeps, renderGitGraphPane, fetchGitGraphData } from './modul
 
       // Save size to cloud (cloud-only, no agent write)
       cloudSaveLayout(paneData);
+      renderConnectionLines();
 
       document.removeEventListener('mousemove', moveHandler);
       document.removeEventListener('touchmove', moveHandler);
@@ -8477,6 +8505,52 @@ import { initGitGraphDeps, renderGitGraphPane, fetchGitGraphData } from './modul
 
       // Quick View: overlays stay on all panes (no interaction in this mode)
     }
+
+  }
+
+  // ── Follow Mode: folder/git-graph panes follow focused terminal ──
+  let followModeDebounce = null;
+
+  function triggerFollowMode(terminalPane) {
+    if (!terminalPane || terminalPane.type !== 'terminal') return;
+    const cwd = terminalPane.workingDir;
+    if (!cwd) return;
+
+    // Find unpinned folder panes (only follow if exactly 1)
+    const unpinnedFolders = state.panes.filter(p =>
+      p.type === 'folder' && !p._pinned && p.agentId === terminalPane.agentId
+    );
+    if (unpinnedFolders.length === 1) {
+      const fp = unpinnedFolders[0];
+      const normCwd = normPath(cwd);
+      if (normPath(fp.folderPath) !== normCwd) {
+        fp.folderPath = cwd;
+        renderFolderPane(fp);
+        cloudSaveLayout(fp);
+      }
+    }
+
+    // Find unpinned git-graph panes (only follow if exactly 1)
+    const unpinnedGitGraphs = state.panes.filter(p =>
+      p.type === 'git-graph' && !p._pinned && p.agentId === terminalPane.agentId
+    );
+    if (unpinnedGitGraphs.length === 1) {
+      const gg = unpinnedGitGraphs[0];
+      // Use the terminal's cwd — the agent's fetchGraphData will resolve git root
+      // We need to update the repoPath on the agent via PATCH, then re-render
+      if (normPath(gg.repoPath) !== normPath(cwd)) {
+        agentRequest('PATCH', `/api/git-graphs/${gg.id}`, { repoPath: cwd }, gg.agentId)
+          .then(() => {
+            gg.repoPath = cwd;
+            gg.repoName = cwd.split('/').pop();
+            renderGitGraphPane(gg);
+            cloudSaveLayout(gg);
+          })
+          .catch(() => {}); // silently fail if not a git repo
+      }
+    }
+
+    renderConnectionLines();
   }
 
   // Pan canvas to center a pane and focus it
@@ -8507,6 +8581,169 @@ import { initGitGraphDeps, renderGitGraphPane, fetchGitGraphData } from './modul
   // Update canvas transform
   function updateCanvasTransform() {
     canvas.style.transform = `translate(${state.panX}px, ${state.panY}px) scale(${state.zoom})`;
+  }
+
+  // ============================================================================
+  // PANE CONNECTION LINES — SVG lines between related panes sharing a path
+  // ============================================================================
+
+  const CONNECTION_COLORS = [
+    { line: 'rgba(78,201,176,0.35)',  dot: 'rgba(78,201,176,0.6)' },   // teal
+    { line: 'rgba(200,130,240,0.35)', dot: 'rgba(200,130,240,0.6)' },   // purple
+    { line: 'rgba(240,180,80,0.35)',  dot: 'rgba(240,180,80,0.6)' },    // amber
+    { line: 'rgba(100,180,255,0.35)', dot: 'rgba(100,180,255,0.6)' },   // blue
+    { line: 'rgba(255,120,140,0.35)', dot: 'rgba(255,120,140,0.6)' },   // pink
+    { line: 'rgba(130,220,100,0.35)', dot: 'rgba(130,220,100,0.6)' },   // green
+    { line: 'rgba(255,160,100,0.35)', dot: 'rgba(255,160,100,0.6)' },   // orange
+    { line: 'rgba(160,200,255,0.35)', dot: 'rgba(160,200,255,0.6)' },   // ice
+  ];
+
+  function getConnectionColor(pathKey) {
+    let hash = 0;
+    for (let i = 0; i < pathKey.length; i++) {
+      hash = ((hash << 5) - hash + pathKey.charCodeAt(i)) | 0;
+    }
+    return CONNECTION_COLORS[Math.abs(hash) % CONNECTION_COLORS.length];
+  }
+
+  function getPaneGroupPath(pane) {
+    if (pane.type === 'terminal') return pane.workingDir || null;
+    if (pane.type === 'folder')  return pane.folderPath || null;
+    if (pane.type === 'git-graph') return pane.repoPath || null;
+    if (pane.type === 'file') {
+      const fp = pane.filePath;
+      if (!fp) return null;
+      const idx = fp.lastIndexOf('/');
+      return idx > 0 ? fp.slice(0, idx) : null;
+    }
+    return null;
+  }
+
+  // Normalize path: remove trailing slash, collapse //
+  function normPath(p) {
+    if (!p) return null;
+    return p.replace(/\/+$/, '').replace(/\/\/+/g, '/') || '/';
+  }
+
+  let connectionSvg = null;
+  let connectionRafId = null;
+
+  function ensureConnectionSvg() {
+    if (connectionSvg && connectionSvg.parentNode === canvas) return connectionSvg;
+    connectionSvg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    connectionSvg.id = 'pane-connections';
+    connectionSvg.style.cssText = 'position:absolute;top:0;left:0;width:10000px;height:10000px;pointer-events:none;z-index:0;overflow:visible;';
+    canvas.insertBefore(connectionSvg, canvas.firstChild);
+    return connectionSvg;
+  }
+
+  function renderConnectionLines() {
+    if (connectionRafId) return;
+    connectionRafId = requestAnimationFrame(() => {
+      connectionRafId = null;
+      _renderConnectionLines();
+    });
+  }
+
+  // Find the closest edge point between two panes and return connection anchors
+  function getEdgeAnchors(a, b) {
+    const aw = a.width || 0, ah = a.height || 0;
+    const bw = b.width || 0, bh = b.height || 0;
+    const acx = a.x + aw / 2, acy = a.y + ah / 2;
+    const bcx = b.x + bw / 2, bcy = b.y + bh / 2;
+    const dx = bcx - acx, dy = bcy - acy;
+    const absDx = Math.abs(dx), absDy = Math.abs(dy);
+
+    let ax1, ay1, bx1, by1, dir;
+
+    if (absDx > absDy) {
+      // Horizontal: connect left/right edges
+      dir = 'h';
+      if (dx > 0) {
+        ax1 = a.x + aw; ay1 = acy; // right edge of A
+        bx1 = b.x;      by1 = bcy; // left edge of B
+      } else {
+        ax1 = a.x;       ay1 = acy; // left edge of A
+        bx1 = b.x + bw;  by1 = bcy; // right edge of B
+      }
+    } else {
+      // Vertical: connect top/bottom edges
+      dir = 'v';
+      if (dy > 0) {
+        ax1 = acx; ay1 = a.y + ah; // bottom edge of A
+        bx1 = bcx; by1 = b.y;      // top edge of B
+      } else {
+        ax1 = acx; ay1 = a.y;      // top edge of A
+        bx1 = bcx; by1 = b.y + bh; // bottom edge of B
+      }
+    }
+
+    return { ax: ax1, ay: ay1, bx: bx1, by: by1, dir };
+  }
+
+  function _renderConnectionLines() {
+    const svg = ensureConnectionSvg();
+    while (svg.firstChild) svg.removeChild(svg.firstChild);
+
+    // Group panes by normalized path + agentId
+    const groups = new Map();
+    for (const pane of state.panes) {
+      const raw = getPaneGroupPath(pane);
+      const p = normPath(raw);
+      if (!p) continue;
+      const key = `${pane.agentId || ''}::${p}`;
+      if (!groups.has(key)) groups.set(key, { path: p, panes: [] });
+      groups.get(key).panes.push(pane);
+    }
+
+    for (const [, group] of groups) {
+      if (group.panes.length < 2) continue;
+      const color = getConnectionColor(group.path);
+      const panes = group.panes;
+
+      for (let i = 0; i < panes.length; i++) {
+        for (let j = i + 1; j < panes.length; j++) {
+          const { ax, ay, bx, by, dir } = getEdgeAnchors(panes[i], panes[j]);
+
+          // Cubic bezier control points — offset along the connection direction
+          const dist = Math.hypot(bx - ax, by - ay);
+          const offset = Math.min(dist * 0.4, 120);
+          let c1x, c1y, c2x, c2y;
+          if (dir === 'h') {
+            const sign = bx > ax ? 1 : -1;
+            c1x = ax + offset * sign; c1y = ay;
+            c2x = bx - offset * sign; c2y = by;
+          } else {
+            const sign = by > ay ? 1 : -1;
+            c1x = ax; c1y = ay + offset * sign;
+            c2x = bx; c2y = by - offset * sign;
+          }
+
+          const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+          path.setAttribute('d', `M${ax},${ay} C${c1x},${c1y} ${c2x},${c2y} ${bx},${by}`);
+          path.setAttribute('stroke', color.line);
+          path.setAttribute('stroke-width', '2');
+          path.setAttribute('fill', 'none');
+          path.setAttribute('stroke-dasharray', '6 4');
+          svg.appendChild(path);
+
+          // Dots at edge anchor points
+          const dotA = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
+          dotA.setAttribute('cx', ax);
+          dotA.setAttribute('cy', ay);
+          dotA.setAttribute('r', '3');
+          dotA.setAttribute('fill', color.dot);
+          svg.appendChild(dotA);
+
+          const dotB = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
+          dotB.setAttribute('cx', bx);
+          dotB.setAttribute('cy', by);
+          dotB.setAttribute('r', '3');
+          dotB.setAttribute('fill', color.dot);
+          svg.appendChild(dotB);
+        }
+      }
+    }
   }
 
   // Quick View: overlay showing pane type, device, path, claude state

--- a/cloud/src-client/modules/git-graph.js
+++ b/cloud/src-client/modules/git-graph.js
@@ -607,7 +607,44 @@ export async function fetchGitGraphData(paneEl, paneData) {
     const statusEl = paneEl.querySelector('.git-graph-status');
 
     if (data.error) {
-      outputEl.innerHTML = `<span class="git-graph-error">Error: ${data.error}</span>`;
+      const isNotRepo = /not a git repository|not.*work.tree/i.test(data.error);
+      if (isNotRepo) {
+        const shortPath = (data.repoPath || paneData.repoPath || '').replace(/^\/home\/[^/]+/, '~');
+        branchEl.textContent = '';
+        statusEl.textContent = '';
+        // Safe DOM construction for non-repo state
+        outputEl.textContent = '';
+        const wrap = document.createElement('div');
+        wrap.className = 'git-graph-no-repo';
+        const icon = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+        icon.setAttribute('viewBox', '0 0 24 24');
+        icon.setAttribute('width', '32');
+        icon.setAttribute('height', '32');
+        icon.setAttribute('fill', 'none');
+        icon.setAttribute('stroke', 'rgba(255,255,255,0.15)');
+        icon.setAttribute('stroke-width', '1.5');
+        const circle = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
+        circle.setAttribute('cx', '12'); circle.setAttribute('cy', '12'); circle.setAttribute('r', '10');
+        const path1 = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+        path1.setAttribute('d', 'M12 8v4');
+        const path2 = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+        path2.setAttribute('d', 'M12 16h.01');
+        icon.append(circle, path1, path2);
+        const label = document.createElement('div');
+        label.className = 'git-graph-no-repo-label';
+        label.textContent = 'Not a git repository';
+        const pathEl = document.createElement('div');
+        pathEl.className = 'git-graph-no-repo-path';
+        pathEl.textContent = shortPath;
+        wrap.append(icon, label, pathEl);
+        outputEl.appendChild(wrap);
+      } else {
+        const errEl = document.createElement('span');
+        errEl.className = 'git-graph-error';
+        errEl.textContent = data.error;
+        outputEl.textContent = '';
+        outputEl.appendChild(errEl);
+      }
       return;
     }
 

--- a/cloud/src-client/modules/git-graph.js
+++ b/cloud/src-client/modules/git-graph.js
@@ -49,6 +49,9 @@ export function renderGitGraphPane(paneData) {
       ${_ctx.paneNameHtml(paneData)}
       <div class="pane-header-right">
         ${_ctx.shortcutBadgeHtml(paneData)}
+        <button class="folder-toolbar-btn follow-pin-btn" data-tooltip="${paneData._pinned ? 'Unpin (follow terminal)' : 'Pin path (stop following)'}" style="color:${paneData._pinned ? '#e8a060' : 'rgba(255,255,255,0.4)'};">
+          <svg viewBox="0 0 24 24" width="14" height="14" fill="${paneData._pinned ? 'currentColor' : 'none'}" stroke="currentColor" stroke-width="2"><path d="M12 2C9.24 2 7 4.24 7 7c0 1.38.56 2.63 1.46 3.54L12 22l3.54-11.46A5 5 0 0 0 17 7c0-2.76-2.24-5-5-5z"/><circle cx="12" cy="7" r="1.5" fill="${paneData._pinned ? '#1a1a2e' : 'none'}"/></svg>
+        </button>
         <div class="pane-zoom-controls">
           <button class="pane-zoom-btn zoom-out" data-tooltip="Zoom out">\u2212</button>
           <button class="pane-zoom-btn zoom-in" data-tooltip="Zoom in">+</button>
@@ -82,6 +85,16 @@ function setupGitGraphListeners(paneEl, paneData) {
   const graphOutput = paneEl.querySelector('.git-graph-output');
   const pushBtn = paneEl.querySelector('.git-graph-push-btn');
   const modeBtn = paneEl.querySelector('.git-graph-mode-btn');
+
+  // Pin/Unpin (follow mode)
+  const pinBtn = paneEl.querySelector('.follow-pin-btn');
+  if (pinBtn) {
+    pinBtn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      paneData._pinned = !paneData._pinned;
+      renderGitGraphPane(paneData);
+    });
+  }
 
   if (!paneData.graphMode) paneData.graphMode = 'svg';
 


### PR DESCRIPTION
## Summary
- **Connection lines**: SVG bezier curves connect panes that share the same directory path. Lines go edge-to-edge (closest side), color-coded per unique path. Updates on drag, resize, create, delete, and terminal `cd`.
- **Follow mode**: When only one unpinned folder or git-graph pane exists, clicking a terminal auto-navigates that pane to the terminal's working directory. Triggered on click only (not hover) to avoid accidental path changes while moving the mouse across panes.
- **Pin button**: Folder and git-graph pane headers have a 📌 pin toggle to lock the current path and disable follow mode.

### Grouping rules
| Pane type | Group key |
|-----------|-----------|
| Terminal | `workingDir` |
| Folder | `folderPath` |
| Git-graph | `repoPath` |
| File | `dirname(filePath)` |

Same `agentId` required. Panes with matching group keys get connected.

## Test plan
- [ ] Open 2+ panes with the same working directory → bezier lines appear between them
- [ ] Drag/resize a pane → lines follow smoothly
- [ ] Terminal `cd` to a new directory → lines update
- [ ] Click a terminal with 1 folder pane open → folder navigates to terminal's cwd
- [ ] Click pin button on folder pane → stops following terminals
- [ ] Open 2 folder panes → neither follows (independent mode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)