### PR TITLE
fix: match git-graph ref badge colors to branch line colors

### DIFF
--- a/cloud/src-client/modules/git-graph.js
+++ b/cloud/src-client/modules/git-graph.js
@@ -425,16 +425,23 @@ export function renderSvgGitGraph(outputEl, commits, currentBranch) {
 
     let refsHtml = '';
     if (commit.refs) {
+      // Match ref badge colors to graph line color for this commit
+      const hexToRgb = (hex) => {
+        const h = hex.replace('#', '');
+        return `${parseInt(h.slice(0,2),16)},${parseInt(h.slice(2,4),16)},${parseInt(h.slice(4,6),16)}`;
+      };
+      const rgb = hexToRgb(colour);
+      const refStyle = `background:rgba(${rgb},0.15);color:${colour};border:1px solid rgba(${rgb},0.3)`;
       const refParts = commit.refs.split(',').map(r => r.trim()).filter(Boolean);
       for (const ref of refParts) {
         if (ref.startsWith('HEAD -> ')) {
-          refsHtml += `<span class="gg-ref gg-ref-head">${escapeHtml(ref.replace('HEAD -> ', ''))}</span>`;
+          refsHtml += `<span class="gg-ref gg-ref-head" style="${refStyle}">${escapeHtml(ref.replace('HEAD -> ', ''))}</span>`;
         } else if (ref.startsWith('tag: ')) {
           refsHtml += `<span class="gg-ref gg-ref-tag">${escapeHtml(ref.replace('tag: ', ''))}</span>`;
         } else if (ref.startsWith('origin/')) {
-          refsHtml += `<span class="gg-ref gg-ref-remote">${escapeHtml(ref)}</span>`;
+          refsHtml += `<span class="gg-ref gg-ref-remote" style="${refStyle}">${escapeHtml(ref)}</span>`;
         } else {
-          refsHtml += `<span class="gg-ref gg-ref-branch">${escapeHtml(ref)}</span>`;
+          refsHtml += `<span class="gg-ref gg-ref-branch" style="${refStyle}">${escapeHtml(ref)}</span>`;
         }
       }
     }


### PR DESCRIPTION
## Summary
Ref badges (HEAD, branch, remote) now use the same color as the commit's graph line instead of fixed CSS colors. This makes the visual connection between graph lines and branch labels immediately clear.

- Tags keep their distinct yellow color (independent of branch)
- Color is derived from the commit's `branch.colour` index into `GG.COLORS`

## Test plan
- [ ] Open a git-graph pane with multiple branches → ref badges match their branch line color
- [ ] Tags still appear yellow regardless of branch color

🤖 Generated with [Claude Code](https://claude.com/claude-code)