### PR TITLE
Rename ADMIN_TOKEN to TELEMETRY_ADMIN_TOKEN

### DIFF
--- a/cloud/src/config.js
+++ b/cloud/src/config.js
@@ -46,7 +46,7 @@ export const config = {
     webhookUrl: process.env.DISCORD_WEBHOOK_URL || '',
   },
   adminUserId: process.env.ADMIN_USER_ID || '',
-  adminToken: process.env.ADMIN_TOKEN || '',
+  adminToken: process.env.TELEMETRY_ADMIN_TOKEN || '',
   cloudAuthUrl: process.env.CLOUD_AUTH_URL || 'https://app.49agents.com',
   version: process.env.APP_VERSION || '',
   nodeEnv,

--- a/cloud/src/telemetry/ingest.js
+++ b/cloud/src/telemetry/ingest.js
@@ -243,7 +243,7 @@ export function setupTelemetryIngestRoutes(app) {
   // GET /api/admin/telemetry/export pulls the collected data down.
   app.get('/api/admin/telemetry/export', (req, res) => {
     if (!config.adminToken) {
-      return res.status(503).json({ error: 'Export not configured (ADMIN_TOKEN unset)' });
+      return res.status(503).json({ error: 'Export not configured (TELEMETRY_ADMIN_TOKEN unset)' });
     }
 
     const auth = req.get('Authorization') || '';

--- a/cloud/test/onboarding-telemetry.test.js
+++ b/cloud/test/onboarding-telemetry.test.js
@@ -621,3 +621,15 @@ test('onboarding waits until the tutorial is finished', () => {
   assert.ok(redirect !== -1 && call !== -1, 'both present in init');
   assert.ok(call > redirect, 'onboarding starts only after the tutorial redirect check');
 });
+
+test('the export token env var name is consistent', () => {
+  const config = readFileSync(join(here, '..', 'src', 'config.js'), 'utf-8');
+  const ingest = readFileSync(join(here, '..', 'src', 'telemetry', 'ingest.js'), 'utf-8');
+
+  // ADMIN_TOKEN is a reserved name on our host, so the export uses its own.
+  assert.ok(/TELEMETRY_ADMIN_TOKEN/.test(config), 'config reads the namespaced variable');
+  assert.ok(!/process\.env\.ADMIN_TOKEN\b/.test(config), 'no bare ADMIN_TOKEN left');
+
+  // The 503 tells an operator which variable to set, so it has to match.
+  assert.ok(/TELEMETRY_ADMIN_TOKEN unset/.test(ingest), 'error names the right variable');
+});


### PR DESCRIPTION
Follow-up to #48.

`ADMIN_TOKEN` is a reserved variable name on Railway and could not be set, which is why the export endpoint kept returning `503 Export not configured`. The namespaced name is a better fit regardless: it guards the telemetry export and nothing else, so it will not collide with an admin credential for something else later.

The 503 body names the variable an operator needs to set, so it moves with it. A test pins the config key and the error message together, since a stale message here sends someone to set the wrong thing.

## After merging

1. Bump the `deploy` submodule to the new `main`.
2. Set `TELEMETRY_ADMIN_TOKEN` on the **cloud** service in Railway (remove `ADMIN_TOKEN` if it was ever accepted).
3. Hit `GET /api/admin/telemetry/export` with `Authorization: Bearer <token>`. JSON with `instances` and `events` means it is working.

## Already verified in production

The ingest half of #48 is live and working: enrollment returns an instance id, events are accepted, unknown ids are refused with a 404, re-enrolling with the same email continues one identity, and a non-consenting instance gets `accepted: 0, reason: no_consent`. Only the export was blocked by the variable name.

Note that four test instances were created during that verification (`pipeline-check@gmail.com`, `declined-check@gmail.com`, and two without an email). Worth deleting once the export works, so they do not skew early numbers.

50 tests passing.
