### PR TITLE
Release v0.4.0: desktop app version bump

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "49agents-desktop",
-  "version": "0.3.6",
+  "version": "0.4.0",
   "description": "49Agents desktop app for macOS",
   "type": "module",
   "main": "src/main.js",


### PR DESCRIPTION
Bumps `desktop/package.json` to 0.4.0 for the v0.4.0 desktop release.

Built artifacts (mac, arm64 + x64 dmg/zip) produced locally from this branch and ready to attach to the GitHub release once merged.

Included since v0.3.6:
- #54 pane header defaults + HUD hotkey tips
- #53 bottom-left pane resize handle
- #52 tutorial overhaul
- #51 local autoconnect

Note: build is ad-hoc signed and not notarized.