### PR TITLE
refactor(agent): extract shared JSON store from the seven pane services

### DIFF
--- a/agent/services/beads.js
+++ b/agent/services/beads.js
@@ -1,10 +1,11 @@
 import { randomUUID } from 'crypto';
-import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'fs';
+import { existsSync } from 'fs';
 import { join, resolve } from 'path';
 import { execFile } from 'child_process';
 import { promisify } from 'util';
 import { homedir } from 'os';
 import { config } from '../src/config.js';
+import { createJsonStore } from './jsonStore.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -21,38 +22,14 @@ const BEADS_PANES_FILE = join(DATA_DIR, 'beads-panes.json');
 // Allowed status filter values
 const VALID_STATUSES = ['open', 'in_progress', 'closed'];
 
-function ensureDataDir() {
-  if (!existsSync(DATA_DIR)) {
-    mkdirSync(DATA_DIR, { recursive: true });
-  }
-}
+const beadsPanesStore = createJsonStore({
+  file: BEADS_PANES_FILE,
+  key: 'beadsPanes',
+  loadError: '[Beads] Error loading beads panes:',
+  saveError: '[Beads] Error saving beads panes:',
+});
 
-function loadBeadsPanes() {
-  try {
-    ensureDataDir();
-    if (!existsSync(BEADS_PANES_FILE)) {
-      return [];
-    }
-    const data = readFileSync(BEADS_PANES_FILE, 'utf-8');
-    const state = JSON.parse(data);
-    return state.beadsPanes || [];
-  } catch (error) {
-    console.error('[Beads] Error loading beads panes:', error);
-    return [];
-  }
-}
-
-function saveBeadsPanes(beadsPanes) {
-  try {
-    ensureDataDir();
-    const state = { beadsPanes, version: 1 };
-    writeFileSync(BEADS_PANES_FILE, JSON.stringify(state, null, 2));
-  } catch (error) {
-    console.error('[Beads] Error saving beads panes:', error);
-  }
-}
-
-let beadsPanesCache = loadBeadsPanes();
+let beadsPanesCache = beadsPanesStore.load();
 
 /**
  * Find the beads project root by looking for .beads/ directory
@@ -218,7 +195,7 @@ export const beadsService = {
     };
 
     beadsPanesCache.push(beadsPane);
-    saveBeadsPanes(beadsPanesCache);
+    beadsPanesStore.save(beadsPanesCache);
     return beadsPane;
   },
 
@@ -233,7 +210,7 @@ export const beadsService = {
     if (updates.projectPath) pane.projectPath = updates.projectPath;
 
     beadsPanesCache[index] = pane;
-    saveBeadsPanes(beadsPanesCache);
+    beadsPanesStore.save(beadsPanesCache);
     return pane;
   },
 
@@ -241,7 +218,7 @@ export const beadsService = {
     const index = beadsPanesCache.findIndex(p => p.id === id);
     if (index !== -1) {
       beadsPanesCache.splice(index, 1);
-      saveBeadsPanes(beadsPanesCache);
+      beadsPanesStore.save(beadsPanesCache);
     }
   },
 

--- a/agent/services/conversations.js
+++ b/agent/services/conversations.js
@@ -2,8 +2,8 @@ import { homedir } from 'os';
 import { join, basename } from 'path';
 import { readdir, stat, open as fsOpen, readFile as readFileAsync } from 'fs/promises';
 import { randomUUID } from 'crypto';
-import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'fs';
 import { config } from '../src/config.js';
+import { createJsonStore } from './jsonStore.js';
 
 const CLAUDE_PROJECTS_DIR = join(homedir(), '.claude', 'projects');
 const DATA_DIR = config.dataDir;
@@ -475,35 +475,14 @@ async function extractConversation(dirPath, sessionId, format) {
 
 // --- Pane state persistence (same pattern as beads.js) ---
 
-function ensureDataDir() {
-  if (!existsSync(DATA_DIR)) {
-    mkdirSync(DATA_DIR, { recursive: true });
-  }
-}
+const convosPanesStore = createJsonStore({
+  file: CONVOS_PANES_FILE,
+  key: 'conversationsPanes',
+  loadError: '[Conversations] Error loading panes:',
+  saveError: '[Conversations] Error saving panes:',
+});
 
-function loadConvosPanes() {
-  try {
-    ensureDataDir();
-    if (!existsSync(CONVOS_PANES_FILE)) return [];
-    const data = readFileSync(CONVOS_PANES_FILE, 'utf-8');
-    const state = JSON.parse(data);
-    return state.conversationsPanes || [];
-  } catch (error) {
-    console.error('[Conversations] Error loading panes:', error);
-    return [];
-  }
-}
-
-function saveConvosPanes(panes) {
-  try {
-    ensureDataDir();
-    writeFileSync(CONVOS_PANES_FILE, JSON.stringify({ conversationsPanes: panes, version: 1 }, null, 2));
-  } catch (error) {
-    console.error('[Conversations] Error saving panes:', error);
-  }
-}
-
-let convosPanesCache = loadConvosPanes();
+let convosPanesCache = convosPanesStore.load();
 
 export const conversationsService = {
   listConversationsPanes() {
@@ -525,7 +504,7 @@ export const conversationsService = {
       createdAt: new Date().toISOString(),
     };
     convosPanesCache.push(pane);
-    saveConvosPanes(convosPanesCache);
+    convosPanesStore.save(convosPanesCache);
     return pane;
   },
 
@@ -535,7 +514,7 @@ export const conversationsService = {
     const pane = convosPanesCache[index];
     if (updates.dirPath) pane.dirPath = updates.dirPath;
     convosPanesCache[index] = pane;
-    saveConvosPanes(convosPanesCache);
+    convosPanesStore.save(convosPanesCache);
     return pane;
   },
 
@@ -543,7 +522,7 @@ export const conversationsService = {
     const index = convosPanesCache.findIndex(p => p.id === id);
     if (index !== -1) {
       convosPanesCache.splice(index, 1);
-      saveConvosPanes(convosPanesCache);
+      convosPanesStore.save(convosPanesCache);
     }
   },
 

--- a/agent/services/filePanes.js
+++ b/agent/services/filePanes.js
@@ -1,8 +1,9 @@
 import { randomUUID } from 'crypto';
-import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'fs';
+import { writeFileSync, existsSync } from 'fs';
 import { join, basename, resolve } from 'path';
 import { homedir } from 'os';
 import { config } from '../src/config.js';
+import { createJsonStore } from './jsonStore.js';
 import { validateWorkingDirectory } from './sanitize.js';
 import { readTextFileForTransport } from './fileRead.js';
 
@@ -15,12 +16,6 @@ try {
   const { execSync } = await import('child_process');
   localHostname = execSync('hostname', { encoding: 'utf-8' }).trim();
 } catch {}
-
-function ensureDataDir() {
-  if (!existsSync(DATA_DIR)) {
-    mkdirSync(DATA_DIR, { recursive: true });
-  }
-}
 
 /**
  * Expand ~ to home directory
@@ -66,42 +61,15 @@ function writeFileContent(filePath, content) {
   writeFileSync(expandedPath, content, 'utf-8');
 }
 
-/**
- * Load file panes from disk
- */
-function loadFilePanes() {
-  try {
-    ensureDataDir();
-    if (!existsSync(FILE_PANES_FILE)) {
-      return [];
-    }
-    const data = readFileSync(FILE_PANES_FILE, 'utf-8');
-    const state = JSON.parse(data);
-    return state.filePanes || [];
-  } catch (error) {
-    console.error('[FilePanes] Error loading file panes:', error);
-    return [];
-  }
-}
-
-/**
- * Save file panes to disk
- */
-function saveFilePanes(filePanes) {
-  try {
-    ensureDataDir();
-    const state = {
-      filePanes,
-      version: 1,
-    };
-    writeFileSync(FILE_PANES_FILE, JSON.stringify(state, null, 2));
-  } catch (error) {
-    console.error('[FilePanes] Error saving file panes:', error);
-  }
-}
+const filePanesStore = createJsonStore({
+  file: FILE_PANES_FILE,
+  key: 'filePanes',
+  loadError: '[FilePanes] Error loading file panes:',
+  saveError: '[FilePanes] Error saving file panes:',
+});
 
 // In-memory cache
-let filePanesCache = loadFilePanes();
+let filePanesCache = filePanesStore.load();
 
 export const filePaneService = {
   /**
@@ -184,7 +152,7 @@ export const filePaneService = {
     };
 
     filePanesCache.push(filePane);
-    saveFilePanes(filePanesCache);
+    filePanesStore.save(filePanesCache);
 
     return { ...filePane, content };
   },
@@ -212,7 +180,7 @@ export const filePaneService = {
     }
 
     filePanesCache[index] = filePane;
-    saveFilePanes(filePanesCache);
+    filePanesStore.save(filePanesCache);
 
     return filePane;
   },
@@ -224,7 +192,7 @@ export const filePaneService = {
     const index = filePanesCache.findIndex(fp => fp.id === id);
     if (index !== -1) {
       filePanesCache.splice(index, 1);
-      saveFilePanes(filePanesCache);
+      filePanesStore.save(filePanesCache);
     }
   }
 };

--- a/agent/services/folderPanes.js
+++ b/agent/services/folderPanes.js
@@ -1,46 +1,19 @@
 import { randomUUID } from 'crypto';
-import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'fs';
 import { join } from 'path';
 import { config } from '../src/config.js';
+import { createJsonStore } from './jsonStore.js';
 
 const DATA_DIR = config.dataDir;
 const FOLDER_PANES_FILE = join(DATA_DIR, 'folder-panes.json');
 
-function ensureDataDir() {
-  if (!existsSync(DATA_DIR)) {
-    mkdirSync(DATA_DIR, { recursive: true });
-  }
-}
+const folderPanesStore = createJsonStore({
+  file: FOLDER_PANES_FILE,
+  key: 'folderPanes',
+  loadError: '[FolderPanes] Error loading folder panes:',
+  saveError: '[FolderPanes] Error saving folder panes:',
+});
 
-function loadFolderPanes() {
-  try {
-    ensureDataDir();
-    if (!existsSync(FOLDER_PANES_FILE)) {
-      return [];
-    }
-    const data = readFileSync(FOLDER_PANES_FILE, 'utf-8');
-    const state = JSON.parse(data);
-    return state.folderPanes || [];
-  } catch (error) {
-    console.error('[FolderPanes] Error loading folder panes:', error);
-    return [];
-  }
-}
-
-function saveFolderPanes(folderPanes) {
-  try {
-    ensureDataDir();
-    const state = {
-      folderPanes,
-      version: 1,
-    };
-    writeFileSync(FOLDER_PANES_FILE, JSON.stringify(state, null, 2));
-  } catch (error) {
-    console.error('[FolderPanes] Error saving folder panes:', error);
-  }
-}
-
-let folderPanesCache = loadFolderPanes();
+let folderPanesCache = folderPanesStore.load();
 
 export const folderPaneService = {
   listFolderPanes() {
@@ -62,7 +35,7 @@ export const folderPaneService = {
     };
 
     folderPanesCache.push(folderPane);
-    saveFolderPanes(folderPanesCache);
+    folderPanesStore.save(folderPanesCache);
 
     return folderPane;
   },
@@ -80,7 +53,7 @@ export const folderPaneService = {
     }
 
     folderPanesCache[index] = folderPane;
-    saveFolderPanes(folderPanesCache);
+    folderPanesStore.save(folderPanesCache);
 
     return folderPane;
   },
@@ -89,7 +62,7 @@ export const folderPaneService = {
     const index = folderPanesCache.findIndex(f => f.id === id);
     if (index !== -1) {
       folderPanesCache.splice(index, 1);
-      saveFolderPanes(folderPanesCache);
+      folderPanesStore.save(folderPanesCache);
     }
   }
 };

--- a/agent/services/gitGraph.js
+++ b/agent/services/gitGraph.js
@@ -1,10 +1,11 @@
 import { randomUUID } from 'crypto';
-import { readFileSync, writeFileSync, existsSync, mkdirSync, readdirSync, statSync, realpathSync } from 'fs';
+import { existsSync, readdirSync, statSync, realpathSync } from 'fs';
 import { join, relative, resolve } from 'path';
 import { homedir } from 'os';
 import { exec, execSync } from 'child_process';
 import { promisify } from 'util';
 import { config } from '../src/config.js';
+import { createJsonStore } from './jsonStore.js';
 import { validateWorkingDirectory } from './sanitize.js';
 
 const execAsync = promisify(exec);
@@ -12,38 +13,14 @@ const execAsync = promisify(exec);
 const DATA_DIR = config.dataDir;
 const GIT_GRAPHS_FILE = join(DATA_DIR, 'git-graphs.json');
 
-function ensureDataDir() {
-  if (!existsSync(DATA_DIR)) {
-    mkdirSync(DATA_DIR, { recursive: true });
-  }
-}
+const gitGraphsStore = createJsonStore({
+  file: GIT_GRAPHS_FILE,
+  key: 'gitGraphs',
+  loadError: '[GitGraph] Error loading git graphs:',
+  saveError: '[GitGraph] Error saving git graphs:',
+});
 
-function loadGitGraphs() {
-  try {
-    ensureDataDir();
-    if (!existsSync(GIT_GRAPHS_FILE)) {
-      return [];
-    }
-    const data = readFileSync(GIT_GRAPHS_FILE, 'utf-8');
-    const state = JSON.parse(data);
-    return state.gitGraphs || [];
-  } catch (error) {
-    console.error('[GitGraph] Error loading git graphs:', error);
-    return [];
-  }
-}
-
-function saveGitGraphs(gitGraphs) {
-  try {
-    ensureDataDir();
-    const state = { gitGraphs, version: 1 };
-    writeFileSync(GIT_GRAPHS_FILE, JSON.stringify(state, null, 2));
-  } catch (error) {
-    console.error('[GitGraph] Error saving git graphs:', error);
-  }
-}
-
-let gitGraphsCache = loadGitGraphs();
+let gitGraphsCache = gitGraphsStore.load();
 
 /**
  * Fetch structured git graph data for a local repository (async).
@@ -250,7 +227,7 @@ export const gitGraphService = {
     };
 
     gitGraphsCache.push(gitGraph);
-    saveGitGraphs(gitGraphsCache);
+    gitGraphsStore.save(gitGraphsCache);
     return gitGraph;
   },
 
@@ -269,7 +246,7 @@ export const gitGraphService = {
     }
 
     gitGraphsCache[index] = gitGraph;
-    saveGitGraphs(gitGraphsCache);
+    gitGraphsStore.save(gitGraphsCache);
     return gitGraph;
   },
 
@@ -277,7 +254,7 @@ export const gitGraphService = {
     const index = gitGraphsCache.findIndex(g => g.id === id);
     if (index !== -1) {
       gitGraphsCache.splice(index, 1);
-      saveGitGraphs(gitGraphsCache);
+      gitGraphsStore.save(gitGraphsCache);
     }
   },
 

--- a/agent/services/iframes.js
+++ b/agent/services/iframes.js
@@ -1,46 +1,19 @@
 import { randomUUID } from 'crypto';
-import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'fs';
 import { join } from 'path';
 import { config } from '../src/config.js';
+import { createJsonStore } from './jsonStore.js';
 
 const DATA_DIR = config.dataDir;
 const IFRAMES_FILE = join(DATA_DIR, 'iframes.json');
 
-function ensureDataDir() {
-  if (!existsSync(DATA_DIR)) {
-    mkdirSync(DATA_DIR, { recursive: true });
-  }
-}
+const iframesStore = createJsonStore({
+  file: IFRAMES_FILE,
+  key: 'iframes',
+  loadError: '[Iframes] Error loading iframes:',
+  saveError: '[Iframes] Error saving iframes:',
+});
 
-function loadIframes() {
-  try {
-    ensureDataDir();
-    if (!existsSync(IFRAMES_FILE)) {
-      return [];
-    }
-    const data = readFileSync(IFRAMES_FILE, 'utf-8');
-    const state = JSON.parse(data);
-    return state.iframes || [];
-  } catch (error) {
-    console.error('[Iframes] Error loading iframes:', error);
-    return [];
-  }
-}
-
-function saveIframes(iframes) {
-  try {
-    ensureDataDir();
-    const state = {
-      iframes,
-      version: 1,
-    };
-    writeFileSync(IFRAMES_FILE, JSON.stringify(state, null, 2));
-  } catch (error) {
-    console.error('[Iframes] Error saving iframes:', error);
-  }
-}
-
-let iframesCache = loadIframes();
+let iframesCache = iframesStore.load();
 
 export const iframeService = {
   listIframes() {
@@ -62,7 +35,7 @@ export const iframeService = {
     };
 
     iframesCache.push(iframe);
-    saveIframes(iframesCache);
+    iframesStore.save(iframesCache);
 
     return iframe;
   },
@@ -81,7 +54,7 @@ export const iframeService = {
     }
 
     iframesCache[index] = iframe;
-    saveIframes(iframesCache);
+    iframesStore.save(iframesCache);
 
     return iframe;
   },
@@ -90,7 +63,7 @@ export const iframeService = {
     const index = iframesCache.findIndex(f => f.id === id);
     if (index !== -1) {
       iframesCache.splice(index, 1);
-      saveIframes(iframesCache);
+      iframesStore.save(iframesCache);
     }
   }
 };

--- a/agent/services/jsonStore.js
+++ b/agent/services/jsonStore.js
@@ -1,0 +1,50 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
+import { dirname } from 'path';
+
+/**
+ * Creates a JSON-file-backed list store.
+ *
+ * Every pane service persists the same way: a single JSON file holding
+ * `{ [key]: [...], version: 1 }`, created on demand, with read/write errors
+ * logged and swallowed so a corrupt file never takes the agent down.
+ *
+ * @param {object}  options
+ * @param {string}  options.file        Absolute path to the JSON file.
+ * @param {string}  options.key         Property under which the list is stored.
+ * @param {string}  options.loadError   Message logged when a read fails.
+ * @param {string}  options.saveError   Message logged when a write fails.
+ */
+export function createJsonStore({ file, key, loadError, saveError }) {
+  function ensureDataDir() {
+    const dir = dirname(file);
+    if (!existsSync(dir)) {
+      mkdirSync(dir, { recursive: true });
+    }
+  }
+
+  return {
+    load() {
+      try {
+        ensureDataDir();
+        if (!existsSync(file)) {
+          return [];
+        }
+        const data = readFileSync(file, 'utf-8');
+        const state = JSON.parse(data);
+        return state[key] || [];
+      } catch (error) {
+        console.error(loadError, error);
+        return [];
+      }
+    },
+
+    save(items) {
+      try {
+        ensureDataDir();
+        writeFileSync(file, JSON.stringify({ [key]: items, version: 1 }, null, 2));
+      } catch (error) {
+        console.error(saveError, error);
+      }
+    },
+  };
+}

--- a/agent/services/notes.js
+++ b/agent/services/notes.js
@@ -1,53 +1,20 @@
 import { randomUUID } from 'crypto';
-import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'fs';
 import { join } from 'path';
 import { config } from '../src/config.js';
+import { createJsonStore } from './jsonStore.js';
 
 const DATA_DIR = config.dataDir;
 const NOTES_FILE = join(DATA_DIR, 'notes.json');
 
-function ensureDataDir() {
-  if (!existsSync(DATA_DIR)) {
-    mkdirSync(DATA_DIR, { recursive: true });
-  }
-}
-
-/**
- * Load notes from disk
- */
-function loadNotes() {
-  try {
-    ensureDataDir();
-    if (!existsSync(NOTES_FILE)) {
-      return [];
-    }
-    const data = readFileSync(NOTES_FILE, 'utf-8');
-    const state = JSON.parse(data);
-    return state.notes || [];
-  } catch (error) {
-    console.error('[Notes] Error loading notes:', error);
-    return [];
-  }
-}
-
-/**
- * Save notes to disk
- */
-function saveNotes(notes) {
-  try {
-    ensureDataDir();
-    const state = {
-      notes,
-      version: 1,
-    };
-    writeFileSync(NOTES_FILE, JSON.stringify(state, null, 2));
-  } catch (error) {
-    console.error('[Notes] Error saving notes:', error);
-  }
-}
+const notesStore = createJsonStore({
+  file: NOTES_FILE,
+  key: 'notes',
+  loadError: '[Notes] Error loading notes:',
+  saveError: '[Notes] Error saving notes:',
+});
 
 // In-memory cache
-let notesCache = loadNotes();
+let notesCache = notesStore.load();
 
 export const noteService = {
   /**
@@ -79,7 +46,7 @@ export const noteService = {
     };
 
     notesCache.push(note);
-    saveNotes(notesCache);
+    notesStore.save(notesCache);
 
     return note;
   },
@@ -107,7 +74,7 @@ export const noteService = {
     }
 
     notesCache[index] = note;
-    saveNotes(notesCache);
+    notesStore.save(notesCache);
 
     return note;
   },
@@ -119,7 +86,7 @@ export const noteService = {
     const index = notesCache.findIndex(n => n.id === id);
     if (index !== -1) {
       notesCache.splice(index, 1);
-      saveNotes(notesCache);
+      notesStore.save(notesCache);
     }
   }
 };

--- a/agent/test/json-store.test.js
+++ b/agent/test/json-store.test.js
@@ -1,0 +1,70 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { join } from 'path';
+import { mkdtempSync, rmSync, existsSync, readFileSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { createJsonStore } from '../services/jsonStore.js';
+
+/**
+ * The seven pane services (notes, iframes, folder/file panes, git graphs,
+ * beads, conversations) all persist through this store, and the agent shares
+ * its data directory with anything else reading those files. So the on-disk
+ * shape and the failure behaviour are both part of the contract, not just the
+ * happy path.
+ */
+
+function withStore(fn) {
+  const dir = mkdtempSync(join(tmpdir(), '49agents-store-'));
+  const file = join(dir, 'nested', 'things.json');
+  try {
+    fn(createJsonStore({
+      file,
+      key: 'things',
+      loadError: '[Test] load failed:',
+      saveError: '[Test] save failed:',
+    }), file);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+test('an absent file loads as an empty list', () => {
+  withStore((store, file) => {
+    assert.deepEqual(store.load(), []);
+    assert.equal(existsSync(file), false);
+  });
+});
+
+test('saving creates the data directory and round-trips', () => {
+  withStore((store) => {
+    store.save([{ id: 'a' }, { id: 'b' }]);
+    assert.deepEqual(store.load(), [{ id: 'a' }, { id: 'b' }]);
+  });
+});
+
+test('the file keeps the { key, version } shape the services shipped with', () => {
+  withStore((store, file) => {
+    store.save([{ id: 'a' }]);
+    const raw = readFileSync(file, 'utf-8');
+    assert.deepEqual(JSON.parse(raw), { things: [{ id: 'a' }], version: 1 });
+    // Key order and indentation are observable to anything else reading the
+    // file, so pin the exact bytes rather than just the parsed value.
+    assert.equal(raw, JSON.stringify({ things: [{ id: 'a' }], version: 1 }, null, 2));
+  });
+});
+
+test('a corrupt file loads as an empty list instead of throwing', () => {
+  withStore((store, file) => {
+    store.save([]);
+    writeFileSync(file, '{ not json');
+    assert.deepEqual(store.load(), []);
+  });
+});
+
+test('a file missing the key loads as an empty list', () => {
+  withStore((store, file) => {
+    store.save([]);
+    writeFileSync(file, JSON.stringify({ version: 1 }));
+    assert.deepEqual(store.load(), []);
+  });
+});


### PR DESCRIPTION
## Description

The seven pane services in `agent/services/` each carried their own copy of the same JSON-file persistence code: a byte-identical `ensureDataDir()` (all eight copies hash the same) plus a near-identical `loadX()` / `saveX()` pair differing only in filename, state key, and log message.

This extracts that into `agent/services/jsonStore.js` and converts the seven services to use it — **net −66 lines**, no behaviour change.

Each service is converted in its own commit so they can be reviewed or reverted independently.

### Behaviour is preserved exactly

- **On-disk format is byte-identical** — still `{ [key]: [...], version: 1 }` serialised with `JSON.stringify(…, null, 2)`. Key order is preserved (payload first, then `version`), so existing data files are unaffected in both directions.
- **Log messages are passed through verbatim** rather than generated from a prefix. They are not uniform today (`[Conversations] Error loading panes:` omits the noun the others include), so generating them would have quietly changed operator-facing output.
- **The in-memory caches are untouched.** Every service mutates its cache in place (`push` / `splice` / `cache[i] = x`) and never reassigns it, so handing back a stable array reference from `load()` keeps the existing semantics.
- **The load stays eager** at module load, which is what creates the data directory — making it lazy would have moved that side effect.
- **No public surface changes.** `loadX` / `saveX` / `ensureDataDir` were module-private in all seven; `messageRouter.js` only ever imports the `*Service` objects, so the `/api/*` responses are untouched.

### Deliberately out of scope

`services/storage.js` has the same-looking `ensureDataDir()` but is **not** the same pattern, so it is left alone:

1. Its loader is `return state.terminals;` with no `|| []` fallback, unlike the other seven. Routing it through the shared store would change what it returns for a file that exists but lacks the key.
2. It has no in-memory cache — `tmux.js` calls `loadTerminalState()` expecting a fresh disk read.
3. Its `loadTerminalState` / `saveTerminalState` are exported and consumed by `tmux.js`.

Happy to follow up on the `|| []` inconsistency separately if you consider it a bug — it seemed wrong to change behaviour inside a refactor PR.

### Testing

`agent/test/json-store.test.js` adds five tests covering the round-trip plus the failure modes the services rely on: absent file → `[]`, corrupt JSON → `[]` (logged, not thrown), missing key → `[]`, and an exact-bytes assertion pinning the on-disk shape.

`npm test` in `agent/`: **94 passing, 0 failing** (89 before this PR, 5 new).

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

Refactor — none of the above categories fit; no behaviour or API change.

## CLA Agreement

- [x] I have read and agree to the [Contributor License Agreement](CLA.md)
