### PR TITLE
fix: local agent identity, terminal-attach crash, and non-default tmux socket

### DIFF
--- a/agent/src/messageRouter.js
+++ b/agent/src/messageRouter.js
@@ -157,9 +157,17 @@ export function createMessageRouter(sendToRelay, options = {}) {
       if (!alreadyWired) {
         wiredTerminals.add(terminalId);
 
-        // Wire error handler once to prevent crash on ttyd failures
+        // Wire error handler once to prevent crash on ttyd failures.
+        // Also unwires on error, same as the 'closed' handler below: an
+        // errored attachment's emitter is done, and attachTerminal() hands
+        // back a brand-new EventEmitter on the next attach attempt. Leaving
+        // this terminalId marked "wired" would skip listening on that new
+        // emitter entirely, so its next error would have zero listeners —
+        // and an EventEmitter throws on an unhandled 'error' event, killing
+        // the whole agent process.
         emitter.on('error', (message) => {
           console.error(`[Terminal] Error for ${terminalId.slice(0,8)}:`, message);
+          wiredTerminals.delete(terminalId);
           sendToRelay(MSG.TERMINAL_ERROR, { terminalId, message });
         });
 

--- a/agent/src/terminalManager.js
+++ b/agent/src/terminalManager.js
@@ -4,8 +4,13 @@ import WebSocket from 'ws';
 import { tmuxService } from '../services/tmux.js';
 import { config } from './config.js';
 
-// tmux command prefix for this instance (see agent/src/instance.js).
+// tmux command prefix for this instance (see agent/src/instance.js). A
+// non-default instance runs its own tmux server on a dedicated socket
+// ('tmux -L <instanceKey>'), so anything that attaches to a session — not
+// just tmuxService's own CLI calls — has to name that socket too, or it
+// attaches against the default server where the session doesn't exist.
 const TMUX = config.tmuxCommand;
+const TMUX_ARGS = TMUX.split(' ').slice(1);
 
 // Track ttyd processes by tmux session
 const ttydProcesses = new Map();
@@ -154,7 +159,7 @@ async function startTtyd(tmuxSession) {
     const ttyd = spawn('ttyd', [
       '-p', String(port),
       '-W',
-      'tmux', 'attach-session', '-t', tmuxSession,
+      'tmux', ...TMUX_ARGS, 'attach-session', '-t', tmuxSession,
     ], {
       stdio: ['ignore', 'pipe', 'pipe'],
     });

--- a/cloud/src/auth/agentAuth.js
+++ b/cloud/src/auth/agentAuth.js
@@ -8,7 +8,7 @@
 
 import { jwtVerify, SignJWT } from 'jose';
 import { config } from '../config.js';
-import { upsertUser, getUserById } from '../db/users.js';
+import { upsertUser, getUserById, getOrCreateLocalSharedUser } from '../db/users.js';
 import { upsertDevAgent } from '../db/agents.js';
 import { getLocalAuth } from './localAuth.js';
 import { hostname as osHostname } from 'os';
@@ -79,16 +79,32 @@ export async function verifyAgentToken(token, instanceKey) {
       };
     }
 
-    // Local mode: use the cloud-authenticated identity
+    // Local mode: prefer the cloud-authenticated identity when this instance
+    // has gone through that flow (see localAuth.js).
     const localAuth = getLocalAuth();
-    if (!localAuth) {
-      throw new Error('Local instance not authenticated with cloud. Open the app in your browser to sign in first.');
+    if (localAuth) {
+      const user = getUserById(localAuth.cloudUserId) || upsertUser({
+        githubLogin: localAuth.githubLogin,
+        email: localAuth.email,
+        displayName: localAuth.displayName || 'Local User',
+        avatarUrl: localAuth.avatarUrl,
+      });
+      return {
+        agentId: resolveDevAgent(instanceKey, user.id),
+        userId: user.id,
+      };
     }
-    const user = getUserById(localAuth.cloudUserId) || upsertUser({
-      githubLogin: localAuth.githubLogin,
-      email: localAuth.email,
-      displayName: localAuth.displayName || 'Local User',
-      avatarUrl: localAuth.avatarUrl,
+
+    // Most 'open' deployments never complete that flow — the browser instead
+    // resolves through autoLocalSession's shared-identity fallback (see
+    // middleware.js). Mirror that here so the agent lands on the same user
+    // the browser already created, instead of refusing to connect.
+    const { ensureLocalSession, getEmailAuth } = await import('./emailAuth.js');
+    const { instanceId } = ensureLocalSession();
+    const emailAuth = getEmailAuth();
+    const user = getOrCreateLocalSharedUser(instanceId, {
+      email: emailAuth?.email || null,
+      displayName: emailAuth?.email ? emailAuth.email.split('@')[0] : 'Local User',
     });
     return {
       agentId: resolveDevAgent(instanceKey, user.id),


### PR DESCRIPTION
## Summary

Three bugs hit together when running a non-default self-hosted instance in `open` auth mode (no OAuth, e.g. `TC_CLOUD_URL` pointing at a non-default host/port) and trying to use terminals:

- **`cloud/src/auth/agentAuth.js`** — the agent's `dev`-token path only accepted the OAuth-bridged `local_auth` identity and threw ("Local instance not authenticated with cloud. Open the app in your browser to sign in first.") whenever that table was empty — which it is for most `open` deployments, since the browser instead resolves through `autoLocalSession`'s shared-identity fallback (`local_email_auth` → `getOrCreateLocalSharedUser`, see `auth/middleware.js`). The agent now falls back the same way, landing on the same user the browser already created instead of refusing to connect.

- **`agent/src/messageRouter.js`** — `attachTerminal()` hands back a brand-new `EventEmitter` whenever the previous attachment isn't reusable (failed connect, dead socket). `messageRouter` only wires listeners once per `terminalId` (`wiredTerminals`), and its `'closed'` handler correctly clears that flag, but its `'error'` handler didn't. An errored attachment left the `terminalId` marked "wired" forever, so the next attach's new emitter got zero listeners — and Node throws on an unhandled `'error'` event, crashing the whole agent process (taking every other terminal down with it).

- **`agent/src/terminalManager.js`** — a non-default instance runs its own tmux server on a dedicated socket (`tmux -L <instanceKey>`, see `instance.js`), and `tmuxService` uses that prefix everywhere it shells out to tmux. `terminalManager`'s `startTtyd()` hardcoded a bare `'tmux'` for the command `ttyd` spawns to attach to the session, so on any non-default instance it attached against the wrong (default) tmux server, which never has the session. tmux printed `can't find session` and exited immediately, and ttyd/libwebsockets reacts to that by sending a close frame with the literal (spec-invalid) code 1006 — surfaced by the `ws` client as `Invalid WebSocket frame: invalid status code 1006`. Every terminal attach on a non-default instance hit this.

Found and fixed while setting up a self-hosted instance reachable only over Tailscale — none of these are Tailscale-specific, they reproduce on any non-default-instance, no-OAuth deployment.

## Test plan

- [x] Started a second cloud server instance on a non-default port with `AUTH_MODE` unset (open mode), no OAuth configured.
- [x] Confirmed a browser session creates a shared local user via `local_email_auth`.
- [x] Started the agent with `TC_CLOUD_URL` pointing at that instance; before the fix it refused to authenticate, after the fix it registers under the same user the browser created (verified via direct DB inspection — same `user_id` in `agents` and `users`).
- [x] Reproduced the terminal-attach crash (agent process exit on an unhandled `'error'` event) by forcing a failed attach followed by a retry; confirmed the agent now logs the error and stays up.
- [x] Reproduced `Invalid WebSocket frame: invalid status code 1006` on every terminal attach on the non-default instance; confirmed `ttyd`'s spawned command now includes `-L <instanceKey>` and attaches successfully, with terminal I/O working end-to-end in the browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)